### PR TITLE
fix Instagram and LinkedIn links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ author:
   goodreads        : # Username
   google_plus      : # Username
   keybase          : # Username
-  instagram        : "@scienceonthewalls"
+  instagram        : "scienceonthewalls"
   lastfm           : # Username
   linkedin         : "science-on-the-walls"
   mastodon         : # URL

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -112,7 +112,7 @@
         <li><a href="https://last.fm/user/{{ author.lastfm }}"><i class="fab fa-fw fa-lastfm icon-pad-right" aria-hidden="true"></i>Last.fm</a></li>
       {% endif %}      
       {% if author.linkedin %}
-        <li><a href="https://www.linkedin.com/in/{{ author.linkedin }}"><i class="fab fa-fw fa-linkedin icon-pad-right" aria-hidden="true"></i>LinkedIn</a></li>
+        <li><a href="https://www.linkedin.com/company/{{ author.linkedin }}"><i class="fab fa-fw fa-linkedin icon-pad-right" aria-hidden="true"></i>LinkedIn</a></li>
       {% endif %}      
       {% if author.mastodon %}
         <li><a href="{{ author.mastodon }}"><i class="fab fa-fw fa-mastodon icon-pad-right" aria-hidden="true"></i>Mastodon</a></li>


### PR DESCRIPTION
I fixed both links that were broken. Instagram link just needed the "@" to be removed in the config.yml file. LinkedIn link had to be fixed in the html template file.